### PR TITLE
Region-of-interest selection & statistics about the ROI

### DIFF
--- a/BrimView-widgets/brimview_widgets/__init__.py
+++ b/BrimView-widgets/brimview_widgets/__init__.py
@@ -10,6 +10,7 @@ from . sampledata_loader import SampledataLoader
 from .bls_metadata import BlsMetadata
 from .debug_report_widget import DebugReport
 from .environment import running_from_pyodide
+from .bls_statistics import BlsStatistics
 
 # Keep treatment widget out of the wasm package
 if running_from_pyodide:

--- a/BrimView-widgets/brimview_widgets/bls_data_visualizer.py
+++ b/BrimView-widgets/brimview_widgets/bls_data_visualizer.py
@@ -627,7 +627,7 @@ class BlsDataVisualizer(WidgetBase, PyComponent):
 
         # Style: red overlay, transparent where mask=0
         mask_img = mask_img.opts(
-            cmap=["grey", "red"],  # 0 → transparent, 1 → red
+            cmap=["grey", "red"],  # 0 → grey, 1 → red
             alpha=0.4,  # overall transparency
             framewise=True,
             tools=[],  # no tools for mask

--- a/BrimView-widgets/brimview_widgets/bls_data_visualizer.py
+++ b/BrimView-widgets/brimview_widgets/bls_data_visualizer.py
@@ -587,7 +587,10 @@ class BlsDataVisualizer(WidgetBase, PyComponent):
             mask = mask.reshape((ny, nx))
             mask = xr.DataArray(
                 mask,
-                dims=["y", "x"],
+                dims=[
+                    "y",
+                    "x",
+                ],  # This should be fine, because that's what hv.Image expects
                 coords={
                     "x": coordinates_xy[0],
                     "y": coordinates_xy[1],

--- a/BrimView-widgets/brimview_widgets/bls_data_visualizer.py
+++ b/BrimView-widgets/brimview_widgets/bls_data_visualizer.py
@@ -5,8 +5,9 @@ import param
 import holoviews as hv
 from holoviews import streams
 
+from .utils import points_in_polygon
 try:
-    from matplotlib.path import Path
+    import scipy
 
     _GUI_ROI_SELECTION = True
 except ImportError:
@@ -582,8 +583,7 @@ class BlsDataVisualizer(WidgetBase, PyComponent):
             xv, yv = np.meshgrid(coordinates_xy[0], coordinates_xy[1])  # yx coordinates
             points = np.column_stack([xv.ravel(), yv.ravel()])
 
-            polygon = Path(lasso_xy)
-            mask = polygon.contains_points(points)
+            mask = points_in_polygon(points, lasso_xy)
             mask = mask.reshape((ny, nx))
             mask = xr.DataArray(
                 mask,

--- a/BrimView-widgets/brimview_widgets/bls_data_visualizer.py
+++ b/BrimView-widgets/brimview_widgets/bls_data_visualizer.py
@@ -483,6 +483,10 @@ class BlsDataVisualizer(WidgetBase, PyComponent):
         logger.debug("_plot_data")
         frame = self._get_datasetslice()
         img = hv.Image(frame)
+
+        # If we need to replot the data, then the mask is probably meaningless anyways
+        # The argument is needed to match the signature of the PlotReset stream
+        self._reset_mask(True) 
         
         if (
             self.bls_data is None

--- a/BrimView-widgets/brimview_widgets/bls_spectrum.py
+++ b/BrimView-widgets/brimview_widgets/bls_spectrum.py
@@ -251,6 +251,7 @@ class BlsSpectrumVisualizer(WidgetBase, PyComponent):
         self.bls_spectrum_in_image = None
         params["name"] = "Spectrum visualization"
         super().__init__(**params)
+        self.tooltip = "**Click on the image** to display the spectrum at the selected pixel. If a fit model is available, it will be displayed as well."
         # Watch tap stream updates
 
         # Reference to the "main" plot_click
@@ -393,7 +394,7 @@ class BlsSpectrumVisualizer(WidgetBase, PyComponent):
             self.spinner.name = "Idle"
             self.spinner.visible = True
 
-    def rewrite_card_header(self, card: pn.Card):
+    def rewrite_card_header(self, card: pn.Card, tooltip: str = None):
         """
         Changes a bit how the header of the card is displayed.
         We replace the default title by
@@ -409,7 +410,10 @@ class BlsSpectrumVisualizer(WidgetBase, PyComponent):
         self.spinner.align = ("end", "center")
         self.spinner.margin = (10, 30)
         header = pn.FlexBox(
-            pn.pane.HTML(**params),
+            pn.Row(
+                pn.pane.HTML(**params),
+                pn.widgets.TooltipIcon(value=tooltip) if tooltip else pn.Spacer(),
+            ),
             # self.spinner,
             # pn.Spacer(),  # pushes next item to the right
             self.spinner,
@@ -814,5 +818,5 @@ class BlsSpectrumVisualizer(WidgetBase, PyComponent):
             sizing_mode="stretch_height",
         )
 
-        self.rewrite_card_header(card)
+        self.rewrite_card_header(card, self.tooltip)
         return card

--- a/BrimView-widgets/brimview_widgets/bls_spectrum.py
+++ b/BrimView-widgets/brimview_widgets/bls_spectrum.py
@@ -414,15 +414,12 @@ class BlsSpectrumVisualizer(WidgetBase, PyComponent):
                 pn.pane.HTML(**params),
                 pn.widgets.TooltipIcon(value=tooltip) if tooltip else pn.Spacer(),
             ),
-            # self.spinner,
-            # pn.Spacer(),  # pushes next item to the right
             self.spinner,
             align_content="space-between",
             align_items="center",  # Vertical-ish
             sizing_mode="stretch_width",
             justify_content="space-between",
         )
-        # header.styles = {"place-content": "space-between"}
         card.header = header
         card._header_layout.styles = {"width": "inherit"}
 

--- a/BrimView-widgets/brimview_widgets/bls_statistics.py
+++ b/BrimView-widgets/brimview_widgets/bls_statistics.py
@@ -339,15 +339,12 @@ class BlsStatistics(WidgetBase, PyComponent):
                 pn.pane.HTML(**params),
                 pn.widgets.TooltipIcon(value=tooltip) if tooltip else pn.Spacer(),
             ),
-            # self.spinner,
-            # pn.Spacer(),  # pushes next item to the right
             self.spinner,
             align_content="space-between",
             align_items="center",  # Vertical-ish
             sizing_mode="stretch_width",
             justify_content="space-between",
         )
-        # header.styles = {"place-content": "space-between"}
         card.header = header
         card._header_layout.styles = {"width": "inherit"}
 

--- a/BrimView-widgets/brimview_widgets/bls_statistics.py
+++ b/BrimView-widgets/brimview_widgets/bls_statistics.py
@@ -1,0 +1,236 @@
+from typing import ClassVar
+
+import scipy
+
+from .bls_data_visualizer import BlsDataVisualizer
+from brimview_widgets.bls_types import bls_param
+import panel as pn
+from panel.io import hold
+import param
+import holoviews as hv
+from holoviews import streams
+
+from holoviews.selection import link_selections
+from matplotlib.path import Path
+
+import numpy as np
+import xarray as xr
+
+from .logging import logger
+
+import brimfile as bls
+from .bls_file_input import BlsFileInput
+from .utils import only_on_change, catch_and_notify
+from .widgets import HorizontalEditableIntSlider
+import colorcet as cc
+import pandas as pd
+
+import sys
+
+# DEBUG
+import time
+import datetime as dt
+
+from panel.widgets.base import WidgetBase
+from panel.custom import PyComponent
+
+
+class BlsStatistics(WidgetBase, PyComponent):
+    """
+    Widget to compute and display basic statistics of selected regions in BLS data.
+    """
+
+    # === References to external objects ===
+    bls_data = param.ClassSelector(
+        class_=bls_param,
+        default=None,
+        precedence=-1,
+        doc="The current selected BLS file/data",
+        allow_refs=True,
+    )
+
+    img_mask = param.Parameter(
+        default=None,
+        precedence=-1,
+        doc="Selection mask from the data visualizer",
+        allow_refs=True,
+    )
+
+    # Information to go from displayed mask to bls data coordinates
+    img_axis_1 = param.Selector(
+        default="x", objects=["x", "y", "z"], label="Horizontal axis", allow_refs=True
+    )
+    img_axis_2 = param.Selector(
+        default="y", objects=["x", "y", "z"], label="Vertical axis", allow_refs=True
+    )
+    img_axis_3 = param.Selector(default="z", objects=["x", "y", "z"], allow_refs=True)
+    img_axis_3_slice = param.Integer(
+        default=0, label="3rd axis slice selector", allow_refs=True
+    )
+
+    # === Internal state ===
+    selected_points = param.List(
+        default=[],
+        precedence=-1,
+        doc="List of selected points (z, y, x ) in data coordinates",
+    )
+
+    def __init__(self, result_plot: BlsDataVisualizer, **params):
+        params["name"] = "Group Statistics"
+        super().__init__(**params)
+
+        # TODO: update result_plot to use this new class
+        self.bls_data: bls_param = bls_param(
+            file=result_plot.param.bls_file,
+            data=result_plot.param.bls_data,
+            analysis=result_plot.param.bls_analysis,
+        )
+
+        self.img_mask = result_plot.param.mask
+        self.img_axis_1 = result_plot.param.img_axis_1
+        self.img_axis_2 = result_plot.param.img_axis_2
+        self.img_axis_3 = result_plot.param.img_axis_3
+        self.img_axis_3_slice = result_plot.param.img_axis_3_slice
+
+        # Because we're not a pn.Viewer anymore, by default we lost the "card" display
+        # so despite us returning a card from __panel__, the shown card didn't match
+        # the card display (background color, shadows)
+        self.css_classes.append("card")
+
+        # Typing hints
+        self.bls_data: bls_param
+        self.img_mask: xr.DataArray
+        self.selected_points: list[tuple[int, int, int]]
+
+    @pn.depends("img_mask", watch=True)
+    def _mask_updated(self):
+        print("Statistics widget: mask updated")
+        # Here we would compute statistics based on the updated mask
+
+    @pn.depends("img_mask")
+    def mask_status(self):
+        if self.img_mask is None:
+            return "No selection"
+        else:
+            num_selected = np.count_nonzero(self.img_mask)
+            total_pixels = self.img_mask.size
+            pct_selected = 100 * num_selected / total_pixels
+            return f"Selected pixels: {num_selected} ({pct_selected:.2f}%)"
+
+    @pn.depends("img_mask", watch=True)
+    def update_selected_points(self):
+        """Update the list of selected points based on the current image mask."""
+        if self.img_mask is None:
+            self.selected_points = []
+        else:
+            self.selected_points = self.mask_to_list(self.img_mask)
+
+    def mask_to_list(self, mask: xr.DataArray) -> list[tuple[int, int, int]]:
+        """Convert a 2D mask DataArray to a list of selected points (z, y, x)."""
+        selected_points = []
+        mask_indices = np.argwhere(mask.values)
+        for idx in mask_indices:
+            y_displayed, x_displayed = idx
+            # Assuming single z slice for simplicity; extend as needed
+
+            # TODO: Maybe it's time now to create a proper coordinate mapper class?
+            match self.img_axis_1:
+                case "x":
+                    x = x_displayed
+                case "y":
+                    y = x_displayed
+                case "z":
+                    z = x_displayed
+            match self.img_axis_2:
+                case "x":
+                    x = y_displayed
+                case "y":
+                    y = y_displayed
+                case "z":
+                    z = y_displayed
+            match self.img_axis_3:
+                case "x":
+                    x = self.img_axis_3_slice
+                case "y":
+                    y = self.img_axis_3_slice
+                case "z":
+                    z = self.img_axis_3_slice
+
+            selected_points.append((z, y, x))
+        return selected_points
+
+    @pn.depends("selected_points")
+    def selected_points_widget(self):
+        if not self.selected_points:
+            return pn.pane.Markdown("No points selected.")
+        else:
+            df = pd.DataFrame(self.selected_points, columns=["z", "y", "x"])
+            return pn.widgets.DataFrame(df, autosize_mode="fit_columns", height=200)
+
+    @pn.depends("selected_points")
+    # @catch_and_notify(prefix="<b>Compute average spectrum: </b>")
+    def average_spectrum_widget(self):
+        if not self.selected_points or self.bls_data is None:
+            logger.debug(
+                "No points selected or no BLS data loaded for average spectrum"
+            )
+            return pn.pane.Markdown("No points selected or no BLS data loaded.")
+        else:
+            # Retrieve spectra for selected points
+            retrieved_PSD = []
+            retrieved_frequency = []
+            for z, y, x in self.selected_points:
+                PSD, frequency, PSD_units, frequency_units = (
+                    self.bls_data.data.get_spectrum_in_image((z, y, x))
+                )
+                retrieved_PSD.append(PSD)
+                retrieved_frequency.append(frequency)
+
+            # Generate average PSD
+            # Figuring out which frequency axis to use
+            n_data_points = len(
+                retrieved_PSD[0]
+            )  # Assuming they all have the same number of points
+            freq_min = np.nanmin(retrieved_frequency)
+            freq_max = np.nanmax(retrieved_frequency)
+            common_freq = np.linspace(freq_min, freq_max, n_data_points)  # shape (71,)
+
+            # Interpolating all the PSDs to the common frequency axis
+            interpolated_psd = np.empty((len(self.selected_points), len(common_freq)))
+            for i in range(len(self.selected_points)):
+                interp_func = scipy.interpolate.interp1d(
+                    retrieved_frequency[i],
+                    retrieved_PSD[i],
+                    kind="linear",
+                    bounds_error=False,
+                    fill_value="extrapolate",
+                )
+                interpolated_psd[i, :] = interp_func(common_freq)
+
+            mean_spectrum = np.mean(interpolated_psd, axis=0)  # shape (71,)
+            std_spectrum = np.nanstd(interpolated_psd, axis=0)
+            curve = hv.Curve(
+                (common_freq, mean_spectrum),
+                hv.Dimension("Frequency", unit=frequency_units),
+                hv.Dimension("PSD", unit=PSD_units),
+                label=f"Average Spectra",
+            ).opts(
+                tools=["hover"],
+            )
+            spread = hv.Spread((common_freq, mean_spectrum, std_spectrum))
+            plot = curve * spread 
+            return pn.pane.HoloViews(plot)
+
+    def __panel__(self):
+        """Create Panel layout for the statistics widget."""
+        card = pn.Card(
+            pn.pane.Markdown(
+                "## Statistics\n\nStatistics of selected regions will be displayed here."
+            ),
+            self.average_spectrum_widget,
+            self.mask_status,
+            self.selected_points_widget,
+            title="BLS Statistics",
+            sizing_mode="stretch_height",
+        )
+        return card

--- a/BrimView-widgets/brimview_widgets/bls_statistics.py
+++ b/BrimView-widgets/brimview_widgets/bls_statistics.py
@@ -5,6 +5,7 @@ from .bls_types import bls_param
 import panel as pn
 from panel.widgets.base import WidgetBase
 from panel.custom import PyComponent
+from bokeh.models.widgets.tables import ScientificFormatter
 import param
 import holoviews as hv
 import numpy as np
@@ -373,6 +374,10 @@ class BlsStatistics(WidgetBase, PyComponent):
             hidden_columns=["Peak", "Description"],
             configuration={
                 "groupStartOpen": True  # This makes all groups collapsed initially
+            },
+            formatters={
+                "Mean": ScientificFormatter(precision=3),
+                "Std": ScientificFormatter(precision=3)
             },
             layout="fit_columns",
             sizing_mode="stretch_width",

--- a/BrimView-widgets/brimview_widgets/bls_statistics.py
+++ b/BrimView-widgets/brimview_widgets/bls_statistics.py
@@ -16,7 +16,6 @@ import pandas as pd
 
 ZYXPoints = list[tuple[int, int, int]]
 
-
 class BlsStatistics(WidgetBase, PyComponent):
     """
     Widget to compute and display basic statistics of selected regions in BLS data.

--- a/BrimView-widgets/brimview_widgets/bls_types.py
+++ b/BrimView-widgets/brimview_widgets/bls_types.py
@@ -22,3 +22,7 @@ class bls_param(param.Parameterized):
             self.file = None
             self.data = None
             self.analysis = None
+    
+    def is_loaded(self) -> bool:
+        logger.debug(f"Checking if bls_input is fully loaded: file {self.file is not None}, data {self.data is not None}, analysis {self.analysis is not None}")
+        return self.file is not None and self.data is not None and self.analysis is not None

--- a/BrimView-widgets/pyproject.toml
+++ b/BrimView-widgets/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 processing = ["HDF5_BLS_treat", "scipy"]
 localfile = ["tkinterdnd2"]
 remote-store = [ "brimfile[remote-store]"]
-statistics = ["scipy", "matplotlib"]
+statistics = ["scipy"]
 
 [project.urls]
 Homepage = "https://github.com/prevedel-lab/BrimView"

--- a/BrimView-widgets/pyproject.toml
+++ b/BrimView-widgets/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 ]
 description = "Widget to display Brimfile data in a Panel application"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 classifiers = [
     "Operating System :: OS Independent",
     "Development Status :: 4 - Beta",
@@ -42,6 +42,7 @@ dependencies = [
 processing = ["HDF5_BLS_treat", "scipy"]
 localfile = ["tkinterdnd2"]
 remote-store = [ "brimfile[remote-store]"]
+statistics = ["scipy", "matplotlib"]
 
 [project.urls]
 Homepage = "https://github.com/prevedel-lab/BrimView"

--- a/dev_getting_started.md
+++ b/dev_getting_started.md
@@ -26,7 +26,7 @@ As there are 3 deployment versions of BrimView, it might be a bit overwhelming t
 ## Installation
 0. Clone this repository 
 1. Create a new .venv enviromment 
-2. Install BrimView-widgets: `pip install -e ".\BrimView-widgets\[processing, localfile, remote-store]`
+2. Install BrimView-widgets: `pip install -e ".\BrimView-widgets\[processing, localfile, remote-store, statistics]`
 3. You should be able to run `panel serve ./src/index.py --dev` now, and everything should be working
 
 ### Web-app

--- a/src/index.py
+++ b/src/index.py
@@ -215,9 +215,10 @@ def build_ui():
     # Brim Visualizer tab
     DataVisualizer = brimview_widgets.BlsDataVisualizer(FileSelector)
     spectrum_visualizer = brimview_widgets.BlsSpectrumVisualizer(DataVisualizer)
+    statistics_widget = brimview_widgets.BlsStatistics(DataVisualizer)
     brim_visualizer = pn.layout.Row(
         pn.layout.FlexBox(DataVisualizer, margin=10),
-        pn.layout.FlexBox(spectrum_visualizer, margin=10),
+        pn.layout.FlexBox([spectrum_visualizer, statistics_widget], margin=10),
         sizing_mode="stretch_width",
     )
     main_tabs.append((".brim Visualizer", brim_visualizer))

--- a/src/index.py
+++ b/src/index.py
@@ -218,7 +218,7 @@ def build_ui():
     statistics_widget = brimview_widgets.BlsStatistics(DataVisualizer)
     brim_visualizer = pn.layout.Row(
         pn.layout.FlexBox(DataVisualizer, margin=10),
-        pn.layout.FlexBox(spectrum_visualizer, statistics_widget, margin=10),
+        pn.layout.FlexBox(spectrum_visualizer, statistics_widget, margin=10, gap="10px"),
         sizing_mode="stretch_width",
     )
     main_tabs.append((".brim Visualizer", brim_visualizer))

--- a/src/index.py
+++ b/src/index.py
@@ -218,7 +218,7 @@ def build_ui():
     statistics_widget = brimview_widgets.BlsStatistics(DataVisualizer)
     brim_visualizer = pn.layout.Row(
         pn.layout.FlexBox(DataVisualizer, margin=10),
-        pn.layout.FlexBox([spectrum_visualizer, statistics_widget], margin=10),
+        pn.layout.FlexBox(spectrum_visualizer, statistics_widget, margin=10),
         sizing_mode="stretch_width",
     )
     main_tabs.append((".brim Visualizer", brim_visualizer))


### PR DESCRIPTION
1. On the main image, adds the lasso select tool to be able to select a region-of-interest.
  i.  Click the bokeh reset button to forget the ROI
  ii. If you redo the display of the data (change some visualization option or change the data), the ROI is also forgotten
  iii. The ROI is displayed as a transparent layer on top of the data (grey = unselected, red = selected)
2.  Create a new widget (called "statistics") that takes the bls_data and the ROI and computes and display some statistics of the pixels inside the ROI
  i. If the ROI is None, then displays nothing
  ii. if there is an ROI, then fetches the PSD and the quantities for all points inside the ROI. (internally, needs to do some 2D -> 3D conversion)
  iii. Computes the average spectrum (with scipy interpolation, extrapolates some points)
  iv. Computes the average for all quantities we have in the dataset
  v. The data fetching process can be slow, so there are some progress bars/busy indicator being displayed.

<img width="1490" height="977" alt="grafik" src="https://github.com/user-attachments/assets/c792192d-feef-4023-900c-4d6e37412201" />

----
- I changed the python version to 3.11
- I also added Tooltip buttons in the header, so that user can know how to interact with the image to use the widgets