### PR TITLE
Backend file information widget

### DIFF
--- a/BrimView-widgets/brimview_widgets/__init__.py
+++ b/BrimView-widgets/brimview_widgets/__init__.py
@@ -17,6 +17,7 @@ if running_from_pyodide:
     from .browser_file_selectors import CustomJSFileInput
     pass #JSFileInput needs to be in the main python file, not in the widgets package
 else:
+    from .bls_zarr_info import BlsZarrInfo
     from .browser_file_selectors import CustomJSFileInput
     from .local_file_selectors import TinkerFileSelector
     from .bls_do_treatment import BlsDoTreatment

--- a/BrimView-widgets/brimview_widgets/bls_metadata.py
+++ b/BrimView-widgets/brimview_widgets/bls_metadata.py
@@ -7,28 +7,69 @@ from panel.custom import PyComponent
 
 import brimfile as bls
 
-from .bls_file_input import BlsFileInput
+from bokeh.models.widgets.tables import HTMLTemplateFormatter
 
 from .utils import catch_and_notify
 from .logging import logger
 
+
 class BlsMetadata(WidgetBase, PyComponent):
     """
-        A widget to display the metadata stored in the brim files.
+    A widget to display the metadata stored in the brim files.
 
-        For Pyodide (ie `panel convert`) reasons, we use a side-effect way to
-        update the tabulator's data.
+    For Pyodide (ie `panel convert`) reasons, we use a side-effect way to
+    update the tabulator's data.
     """
+
     value = param.ClassSelector(
-        class_= bls.Data, default=None, allow_refs=True,
+        class_=bls.Data,
+        default=None,
+        allow_refs=True,
         doc="The names of the features selected and their set values",
     )
 
     def __init__(self, **params):
-        self.tabulator = pn.widgets.Tabulator(show_index=False, disabled=True, groupby=['Group'], hidden_columns=['Group'])
+        self.tabulator = pn.widgets.Tabulator(
+            show_index=False,
+            disabled=True,
+            groupby=["Group"],
+            hidden_columns=["Group"],
+            formatters={
+                "Validity": HTMLTemplateFormatter(
+                    template="""
+<%
+const v = value;
+
+let bg = "#e74c3c";   // default red
+let icon = "✖";
+
+if (v === "valid") {
+    bg = "#2ecc71";
+    icon = "✔";
+}
+else if (v === "unknown field" || v === "likely typo") {
+    bg = "#f39c12";
+    icon = "⚠";
+}
+%>
+<span style="
+    background-color:<%= bg %>;
+    color:white;
+    padding:3px 10px;
+    border-radius:10px;
+    font-size:12px;
+    font-weight:600;
+    white-space:nowrap;
+">
+<%= icon %> <%= v %>
+</span>
+"""
+                )
+            },
+        )
         self.title = pn.pane.Markdown("## Metadata of the file \n Please load a file")
         super().__init__(**params)
-        
+
         logger.info("BlsMetadata initialized")
 
         # Explicit annotation, because param and type hinting is not working properly
@@ -40,24 +81,35 @@ class BlsMetadata(WidgetBase, PyComponent):
         logger.info("Updating metadata tabulator")
         if self.value is None:
             self.title.object = "## Metadata of the file \n Please load a file"
-            self.tabulator.value = None
-            return 
+            self.tabulator_visibility = False
+            #self.tabulator.value = None // <- This can be an issue, if the tabulator is currently trying to order a column
+            return
         self.title.object = "## Metadata of the file"
 
         rows = []
-        for meta_type, parameters in self.value.get_metadata().all_to_dict().items():
+        for meta_type, parameters in (
+            self.value.get_metadata()
+            .all_to_dict(validate=True, include_missing=True)
+            .items()
+        ):
             for name, item in parameters.items():
+                name: str
+                item: bls.metadata.Metadata.Item
                 rows.append(
                     {
                         "Parameter": name,
                         "Value": item.value,
                         "Unit": item.units,
+                        "Validity": item.get_validity().value,
                         "Group": meta_type,
                     }
                 )
 
-        df = pd.DataFrame(rows, columns=["Parameter", "Value", "Unit", "Group"])
+        df = pd.DataFrame(
+            rows, columns=["Parameter", "Value", "Unit", "Group", "Validity"]
+        )
         self.tabulator.value = df
+        self.tabulator_visibility = True
 
     @property
     def tabulator_visibility(self):
@@ -65,20 +117,16 @@ class BlsMetadata(WidgetBase, PyComponent):
         Visibility of the tabulator widget.
 
         This is to allow a workaroung that works in both Pyodide and normal Python:
-        **Bug**: the tabulator gets populated, is invisible (ie not in the active tab) but 
+        **Bug**: the tabulator gets populated, is invisible (ie not in the active tab) but
         is still *above* the other widgets, making them unclickable.
 
-        Potentially related to: https://github.com/holoviz/panel/issues/8053 and https://github.com/holoviz/panel/issues/8103 
+        Potentially related to: https://github.com/holoviz/panel/issues/8053 and https://github.com/holoviz/panel/issues/8103
         """
         return self.tabulator.visible
-    
+
     @tabulator_visibility.setter
     def tabulator_visibility(self, value: bool):
         self.tabulator.visible = value
 
-    def __panel__(self):        
-        return pn.Column(
-            self.title,
-            self.tabulator
-        )
-    
+    def __panel__(self):
+        return pn.Column(self.title, self.tabulator)

--- a/BrimView-widgets/brimview_widgets/bls_zarr_info.py
+++ b/BrimView-widgets/brimview_widgets/bls_zarr_info.py
@@ -1,0 +1,252 @@
+from dataclasses import dataclass, field, asdict
+import json
+from typing import Any, Dict, List, Optional
+
+import panel as pn
+from panel_jstree import Tree
+import param
+import pandas as pd
+
+from panel.widgets.base import WidgetBase
+from panel.custom import PyComponent
+
+import brimfile as bls
+from brimfile.validation.json_descriptor import generate_json_descriptor
+from brimfile.file_abstraction import sync
+
+import zarr
+
+
+from .utils import catch_and_notify
+from .logging import logger
+
+
+class BlsZarrInfo(WidgetBase, PyComponent):
+    """
+    A widget to display the general file information.
+    """
+
+    value = param.ClassSelector(
+        class_=bls.Data,
+        default=None,
+        allow_refs=True,
+        doc="The names of the features selected and their set values",
+    )
+
+    def __init__(self, **params):
+        self.title = pn.pane.Markdown("## Zarr file information")
+        super().__init__(**params)
+
+        # Tabulator to display zarr info 
+        self.info_tabulator = pn.widgets.Tabulator(
+            show_index=False,
+            disabled=True,
+            visible=True,
+            hidden_columns=["Group"],
+        )
+
+        # Tree to display the file structure
+        self.tree = Tree(
+            data=[],
+            select_multiple=False,
+            checkbox=False,
+            plugins=["wholerow"],
+            min_width=300,
+            min_height=300,
+        )
+        # We bind the callback to the tree selection event, to update the details window when a node is selected
+        # ( pn.depend(tree.value) is not working, so this is a quick workaround)
+        pn.bind(self._tree_selected_callback, self.tree.param.value, watch=True)
+
+        # Node details 
+        self.detail_text = pn.pane.Markdown("Click on a node to see its attributes")
+        self.detail_tabulator = pn.widgets.Tabulator(
+            show_index=False,
+            disabled=True,
+            visible=True,
+            groupby=["Group"],
+            hidden_columns=["Group"],
+        )
+
+        # Explicit annotation, because param and type hinting is not working properly
+        self.value: bls.Data
+        logger.info("BlsZarrInfo initialized")
+
+    @catch_and_notify(prefix="<b>Zarr detail display: </b>")
+    def _tree_selected_callback(self, selected_ids):
+        logger.info(f"Zarr tree file selected node changed, selected_ids: {selected_ids}")
+        id = selected_ids[0] if selected_ids else None
+        node = None
+        for n in self.tree._flat_tree:
+            if n["id"] == id:
+                node = n
+                break
+
+        logger.info(f"Selected node: {node}")
+        if node is None:
+            self.detail_tabulator.value = None
+            self.detail_text.object = "Click on a node to see its attributes"
+            return
+        dataframe = dict_to_tabulator_df(node["data"])
+        self.detail_tabulator.value = dataframe
+        self.detail_text.object = (
+            f"Clicked on node: _{node['text']}_."  # TODO: Display the absolute path
+        )
+
+    @param.depends("value")
+    @catch_and_notify(prefix="<b>Zarr file size: </b>")
+    def _size_widget(self):
+        if self.value is None:
+            return pn.pane.Markdown("")
+
+        store = self.value._file._store
+        size = sync(store.getsize_prefix("/"))
+        readable_size = bytes_human_string(size)
+        return pn.pane.Markdown(
+            f"Reported file size: **{readable_size}** (= {size} bytes)"
+        )
+
+    @param.depends("value", watch=True)
+    @catch_and_notify(prefix="<b>Zarr file info: </b>")
+    def _info_widget(self):
+        if self.value is None:
+            self.info_tabulator.value = None
+            return
+        root: zarr.Group = self.value._file._root
+        group_info = sync(root.info_complete())
+        # gropu info is a dataclass
+        self.info_tabulator.value = dict_to_tabulator_df(asdict(group_info))
+
+    @param.depends("value", watch=True)
+    @catch_and_notify(prefix="<b>Update Zarr tree: </b>")
+    def _update_tree_widget(self):
+        if self.value is None:
+            self.tree.data = []
+            return
+        root = self.value._file._root
+
+        logger.info("Converting json_descriptor to pmui.Tree format")
+        json_tree = generate_json_descriptor(root)
+        tree = json.loads(json_tree)
+        typed_tree = brimfilejson_to_jstree(tree)
+        for root_node in typed_tree:
+            root_node.state = NodeState(opened=True)
+        dict_tree = [asdict(node) for node in typed_tree]
+        self.tree.data = dict_tree
+
+    def __panel__(self):
+        return pn.Column(
+            self.title,
+            pn.Row(
+                self.info_tabulator,
+                self._size_widget,
+            ),
+            pn.layout.Divider(height=10, margin=10),
+            pn.FlexBox(
+                pn.Column("### Zarr file tree", self.tree),
+                pn.Column(self.detail_text, "### Attributes", self.detail_tabulator),
+                sizing_mode="scale_width",
+            ),
+        )
+
+
+### === Helper class, functions and other utils ===
+@dataclass
+class NodeState:
+    opened: bool = False
+    selected: bool = False
+    disabled: bool = False
+
+
+@dataclass
+class TreeNode:
+    """
+    A class representing a node in the tree structure.
+    Expected to be consumed by the panel_jstree component: you first need to convert
+    it into a dictonary with `asdict()` before passing to the Tree widget.
+
+    Contains some shared code between different node type.
+    """
+
+    text: str
+    state: Optional[NodeState] = None
+    icon: Optional[str] = None
+    children: List["TreeNode"] = field(default_factory=list)
+
+    data: Dict[str, Any] = field(
+        default_factory=dict
+    )  # Allows to store abitrary data in the node, that can be used for the details dialog for example
+    node_type: str = "group"  # or "array"
+
+    def __post_init__(self):
+        icon_by_node_type = {
+            "group": "jstree-folder",
+            "array": "jstree-file",
+        }
+        if self.icon is None:
+            self.icon = icon_by_node_type.get(self.node_type, "folder")
+
+
+def brimfilejson_to_jstree(brimfile_descriptor) -> List[TreeNode]:
+    """
+    Convert the json_descriptor generated by brimfile into a list of TreeNode,
+    that can be processed by panel_jstree
+    """
+
+    def convert_node(node: dict, node_name) -> Optional[TreeNode]:
+        attributes: dict = node["attributes"]
+        node_type: str = node["node_type"]
+        if node_type == "group":
+            children = node.keys() - {"attributes", "node_type"}
+            return TreeNode(
+                text=node_name,
+                children=[convert_node(node[child], child) for child in children],
+                data=attributes,
+                node_type=node_type,
+            )
+        elif node_type == "array":
+            # For better readability, we convert the shape into a human readable string
+            # We want : "[512, 512]" instead of "512,512"
+            human_pretty_shape = f"[ {', '.join(map(str, node['shape']))} ]"
+            attributes.update({"shape": human_pretty_shape, "dtype": node["dtype"]})
+            return TreeNode(
+                text=node_name,
+                data=attributes,
+                node_type=node_type,
+            )
+        else:
+            return None
+
+    children = brimfile_descriptor.keys() - {"attributes", "node_type"}
+    return [convert_node(brimfile_descriptor[key], key) for key in children]
+
+
+def dict_to_tabulator_df(data: dict) -> pd.DataFrame:
+    rows = []
+
+    def walk(d, path=None):
+        path = path or []
+
+        for key, value in d.items():
+            if isinstance(value, dict):
+                walk(value, path + [key])
+            else:
+                rows.append(
+                    {
+                        "Group": "/".join(path) if path else None,
+                        "Name": key,
+                        "Value": value,
+                    }
+                )
+
+    walk(data)
+
+    return pd.DataFrame(rows)
+
+
+def bytes_human_string(num_bytes):
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if num_bytes < 1024.0:
+            return f"{num_bytes:.2f} {unit}"
+        num_bytes /= 1024.0
+    return f"{num_bytes:.2f} PB"

--- a/BrimView-widgets/brimview_widgets/bls_zarr_info.py
+++ b/BrimView-widgets/brimview_widgets/bls_zarr_info.py
@@ -50,7 +50,7 @@ class BlsZarrInfo(WidgetBase, PyComponent):
             data=[],
             select_multiple=False,
             checkbox=False,
-            plugins=["wholerow"],
+            plugins=["wholerow", "sort"],
             min_width=300,
             min_height=300,
         )
@@ -75,10 +75,10 @@ class BlsZarrInfo(WidgetBase, PyComponent):
     @catch_and_notify(prefix="<b>Zarr detail display: </b>")
     def _tree_selected_callback(self, selected_ids):
         logger.info(f"Zarr tree file selected node changed, selected_ids: {selected_ids}")
-        id = selected_ids[0] if selected_ids else None
+        selected_id = selected_ids[0] if selected_ids else None
         node = None
-        for n in self.tree._flat_tree:
-            if n["id"] == id:
+        for n in self.tree.flat_tree:
+            if n["id"] == selected_id:
                 node = n
                 break
 
@@ -114,7 +114,7 @@ class BlsZarrInfo(WidgetBase, PyComponent):
             return
         root: zarr.Group = self.value._file._root
         group_info = sync(root.info_complete())
-        # gropu info is a dataclass
+        # group info is a dataclass
         self.info_tabulator.value = dict_to_tabulator_df(asdict(group_info))
 
     @param.depends("value", watch=True)
@@ -163,7 +163,7 @@ class TreeNode:
     """
     A class representing a node in the tree structure.
     Expected to be consumed by the panel_jstree component: you first need to convert
-    it into a dictonary with `asdict()` before passing to the Tree widget.
+    it into a dictionary with `asdict()` before passing to the Tree widget.
 
     Contains some shared code between different node type.
     """
@@ -175,7 +175,7 @@ class TreeNode:
 
     data: Dict[str, Any] = field(
         default_factory=dict
-    )  # Allows to store abitrary data in the node, that can be used for the details dialog for example
+    )  # Allows to store arbitrary  data in the node, that can be used for the details dialog for example
     node_type: str = "group"  # or "array"
 
     def __post_init__(self):

--- a/BrimView-widgets/brimview_widgets/bls_zarr_info.py
+++ b/BrimView-widgets/brimview_widgets/bls_zarr_info.py
@@ -37,7 +37,7 @@ class BlsZarrInfo(WidgetBase, PyComponent):
         self.title = pn.pane.Markdown("## Zarr file information")
         super().__init__(**params)
 
-        # Tabulator to display zarr info 
+        # Tabulator to display zarr info
         self.info_tabulator = pn.widgets.Tabulator(
             show_index=False,
             disabled=True,
@@ -58,7 +58,7 @@ class BlsZarrInfo(WidgetBase, PyComponent):
         # ( pn.depend(tree.value) is not working, so this is a quick workaround)
         pn.bind(self._tree_selected_callback, self.tree.param.value, watch=True)
 
-        # Node details 
+        # Node details
         self.detail_text = pn.pane.Markdown("Click on a node to see its attributes")
         self.detail_tabulator = pn.widgets.Tabulator(
             show_index=False,
@@ -74,7 +74,9 @@ class BlsZarrInfo(WidgetBase, PyComponent):
 
     @catch_and_notify(prefix="<b>Zarr detail display: </b>")
     def _tree_selected_callback(self, selected_ids):
-        logger.info(f"Zarr tree file selected node changed, selected_ids: {selected_ids}")
+        logger.info(
+            f"Zarr tree file selected node changed, selected_ids: {selected_ids}"
+        )
         selected_id = selected_ids[0] if selected_ids else None
         node = None
         for n in self.tree.flat_tree:
@@ -82,7 +84,7 @@ class BlsZarrInfo(WidgetBase, PyComponent):
                 node = n
                 break
 
-        logger.info(f"Selected node: {node}")
+        logger.debug(f"Selected node: {node}")
         if node is None:
             self.detail_tabulator.value = None
             self.detail_text.object = "Click on a node to see its attributes"
@@ -96,15 +98,16 @@ class BlsZarrInfo(WidgetBase, PyComponent):
     @param.depends("value")
     @catch_and_notify(prefix="<b>Zarr file size: </b>")
     def _size_widget(self):
+        logger.info("Calculating Zarr file size")
         if self.value is None:
             return pn.pane.Markdown("")
 
         store = self.value._file._store
         size = sync(store.getsize_prefix("/"))
         readable_size = bytes_human_string(size)
-        return pn.pane.Markdown(
-            f"Reported file size: **{readable_size}** (= {size} bytes)"
-        )
+        msg = f"Reported file size: **{readable_size}** (= {size} bytes)"
+        logger.debug(msg)
+        return pn.pane.Markdown(msg)
 
     @param.depends("value", watch=True)
     @catch_and_notify(prefix="<b>Zarr file info: </b>")

--- a/BrimView-widgets/brimview_widgets/bls_zarr_info.py
+++ b/BrimView-widgets/brimview_widgets/bls_zarr_info.py
@@ -123,15 +123,18 @@ class BlsZarrInfo(WidgetBase, PyComponent):
         if self.value is None:
             self.tree.data = []
             return
-        root = self.value._file._root
+        file = self.value._file
 
-        logger.info("Converting json_descriptor to pmui.Tree format")
-        json_tree = generate_json_descriptor(root)
+        logger.debug("Retrieving json descriptor for the Zarr file")
+        json_tree = generate_json_descriptor(file)
+        logger.info("Converting json_descriptor to jstree format")
         tree = json.loads(json_tree)
         typed_tree = brimfilejson_to_jstree(tree)
         for root_node in typed_tree:
             root_node.state = NodeState(opened=True)
         dict_tree = [asdict(node) for node in typed_tree]
+
+        logger.debug("Updating tree widget with new data")
         self.tree.data = dict_tree
 
     def __panel__(self):

--- a/BrimView-widgets/brimview_widgets/utils.py
+++ b/BrimView-widgets/brimview_widgets/utils.py
@@ -89,6 +89,7 @@ def catch_and_notify(duration=4000, notification_type="error", prefix=""):
                 except Exception as e:
                     msg = f"{prefix}{type(e).__name__}: {str(e)}"
                     getattr(pn.state.notifications, notification_type)(msg, duration=duration)
+                    logger.error(f"Error in {func.__name__}: {msg}")
                     return None
             return async_wrapper
         else:
@@ -99,6 +100,7 @@ def catch_and_notify(duration=4000, notification_type="error", prefix=""):
                 except Exception as e:
                     msg = f"{prefix}{type(e).__name__}: {str(e)}"
                     getattr(pn.state.notifications, notification_type)(msg, duration=duration)
+                    logger.error(f"Error in {func.__name__}: {msg}")
                     return None
             return sync_wrapper
     return decorator

--- a/BrimView-widgets/pyproject.toml
+++ b/BrimView-widgets/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "bokeh~=3.8",
   "holoviews~=1.22",
   "panel~=1.8",
+  "panel-jstree~=0.3",
   "xarray",
   "brimfile[export-tiff]"
 ]

--- a/dev_getting_started.md
+++ b/dev_getting_started.md
@@ -33,6 +33,7 @@ As there are 3 deployment versions of BrimView, it might be a bit overwhelming t
 > Changes to the Web-app are a bit more tricky, because you not only need Python but also Javascript/WebDev experience. 
 
 For the pyodide-app to work, we need to have:
+- the python build tooling: `pip install build` (if it's not already there)
 - the .whl for BrimView-widget and Brimfile: run `py ./src/build_deps.py`
 - the converted BrimView app: run `py ./src/build_webapp.py` (currently we only tested it on panel 1.8.3 and earlier versions do not work)
 - put all of that into one folder

--- a/src/index.py
+++ b/src/index.py
@@ -183,8 +183,13 @@ def build_ui():
         # Creating the treatment widget
         TreamentWidget = TreamentWidget_webapp
 
-        # Creating the zarr info widget
-        zarr_info_widget = TreamentWidget_webapp
+        # In the Pyodide/webapp build, backend Zarr inspection is not available.  
+        zarr_info_widget = pn.pane.Markdown(  
+            "### Advanced file information\n\n"  
+            "Advanced Zarr file inspection is not available in this web "  
+            "application build. This feature requires the Zarr library and "  
+            "a running Python backend server."  
+        )  
 
     else:  # We're in `panel serve` case
 

--- a/src/index.py
+++ b/src/index.py
@@ -18,7 +18,7 @@ import HDF5_BLS_treat # Force import of HDF5_BLS_treat
 __version__ = "0.2.2"
 
 hv.extension("bokeh")  # or 'plotly'/'matplotlib' depending on your use
-pn.extension("plotly", "filedropper", "jsoneditor", "tabulator", "modal", notifications=True)
+pn.extension("plotly", "filedropper", "jsoneditor", "tabulator", "modal", "tree", notifications=True)
 pn.extension(
     raw_css=[
         """
@@ -183,6 +183,9 @@ def build_ui():
         # Creating the treatment widget
         TreamentWidget = TreamentWidget_webapp
 
+        # Creating the zarr info widget
+        zarr_info_widget = TreamentWidget_webapp
+
     else:  # We're in `panel serve` case
 
         # Creating the file input widget
@@ -205,7 +208,9 @@ def build_ui():
             TreamentWidget = TreamentWidget_webapp
         else:
             TreamentWidget = brimview_widgets.BlsDoTreatment(FileSelector)
-        
+
+        # Creating the zarr info widget
+        zarr_info_widget = brimview_widgets.BlsZarrInfo(value=FileSelector.param.data)
     
     analyser_placeholder.append(TreamentWidget)
 
@@ -249,6 +254,7 @@ def build_ui():
 
     # "Treatement" tab
     main_tabs.append(("(Re-)analyze spectra", analyser_placeholder))
+    main_tabs.append(("Advanced file information", zarr_info_widget))
 
     # ======
     # Populate the sidebar


### PR DESCRIPTION
Adds a new widget to display information about the backend file (ie Zarr file size, zarr file tree, attributes, etc...).

Should work in `panel serve`, and won't work in pyodide because it needs to call the zarr library